### PR TITLE
Smaller improvements - speedup

### DIFF
--- a/runx
+++ b/runx
@@ -237,7 +237,7 @@ getwslpath() {                  # Get path to currently running WSL system
   # Mark our filesystem with a temporary file having an unique name.
   touch "${RUN_ID}"
 
-  powershell.exe -Command '(Get-ChildItem HKCU:\Software\Microsoft\Windows\CurrentVersion\Lxss | ForEach-Object {Get-ItemProperty $_.PSPath}).BasePath.replace(":", "").replace("\", "/")' | while IFS= read -r BASEPATH; do
+  powershell.exe -Command '(Get-ChildItem HKCU:\Software\Microsoft\Windows\CurrentVersion\Lxss | ForEach-Object {Get-ItemProperty $_.PSPath}).BasePath | where-object {$_ -ne $null} | ForEach-Object { $_.replace(":", "").replace("\", "/") }' | while IFS= read -r BASEPATH; do
     # Remove trailing whitespaces.
     BASEPATH="${BASEPATH%"${BASEPATH##*[![:space:]]}"}"
     # Build the path on WSL.
@@ -287,7 +287,7 @@ check_display() {               # Find unused display number
   return 1
 }
 check_displayport() {           # Return 0 if display number $1 is in use
-  (</dev/tcp/"$Hostip"/$((6000+${1:-})) ) >/dev/null 2>&1
+  timeout 1 bash -c "</dev/tcp/"$Hostip"/$((6000+${1:-})) >/dev/null 2>&1" && return 0 || return 1
 }
 check_host() {                  # Check host environment
   # Check for MS Windows subsystem
@@ -351,7 +351,7 @@ check_xserver() {               # Check for Xwin and VcXsrv
   Vcxsrvbin="$(command -v vcxsrv.exe)"
   [ "$Vcxsrvbin" ] || Vcxsrvbin="$(command -v "$(convertpath subsystem "C:/Program Files/VcXsrv/vcxsrv.exe")")"
   [ "$Vcxsrvbin" ] || Vcxsrvbin="$(command -v "$(convertpath subsystem "C:/Program Files/VcXsrv (x86)/vcxsrv.exe")")"
-  Xwinbin="$(command -v XWin)"
+  Xwinbin="$(command -v XWin)" || Xwinbin="$(command -v XWin.exe)"
   [ -z "$Xwinbin" ] && case $Winsubsystem in
     WSL1|WSL2)
       # search for XWin


### PR DESCRIPTION
1. I had an entry in Lxss without Basepath leading to a null-exception:
<img width="905" alt="image" src="https://user-images.githubusercontent.com/1142765/209485549-2c723023-8149-4e1e-9509-fb7ece1125e0.png">

2. check_displayport sometimes ran into an timeout, not opening anything (especially together with x11docker on wsl2) I think waiting 1s is enough

3. My Cygwin-X has an XWin.exe - in WSL I can just add the folder to the path and don't need to rely on /cygwin64/bin/XWin.exe path.
