### PR TITLE
When on WSL2, check for internal host IP

### DIFF
--- a/runx
+++ b/runx
@@ -326,6 +326,7 @@ check_host() {                  # Check host environment
 
   # Get IP of Windows host
   [ "$Hostip" = "localhost" ] && Hostip="127.0.0.1"
+  [ "$Hostip" ] || [ "$Winsubsystem" = "WSL2" ] && Hostip="$(ip route list default | awk '{print $3}')"
   [ "$Hostip" ] || Hostip="$(ipconfig.exe | rmcr | grep 'IPv4' | grep -o '192\.168\.[0-9]*\.[0-9]*'       | head -n1 )"
   [ "$Hostip" ] || Hostip="$(ipconfig.exe | rmcr | grep 'IPv4' | grep -o '10\.0\.[0-9]*\.[0-9]*'          | head -n1 )"
   [ "$Hostip" ] || Hostip="$(ipconfig.exe | rmcr | grep 'IPv4' | grep -o '[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*' | head -n1 )"
@@ -777,8 +778,8 @@ export XAUTHORITY=$XAUTHORITY" > "$Xenvfile"
 
 trap finish EXIT
 declare_variables
-check_host
 parse_options "$@"
+check_host
 [ "$Cleanup" = "yes" ] && cleanup && Exitcode="${Exitcode:-0}"
 [ -z "$Exitcode" ]     && main
 finish "${Exitcode:-0}"

--- a/runx
+++ b/runx
@@ -303,9 +303,6 @@ check_host() {                  # Check host environment
   Did not detect WSL, Cygwin or MSYS2." ;;
   esac
 
-  [ "$0" = "$BASH_SOURCE" ] && Sourced="no" || Sourced="yes"
-  verbose "Script is being sourced yes/no: $Sourced"
-
   case $Winsubsystem in
     MSYS2|CYGWIN) 
       Winsubmount="$(cygpath.exe -u "c:/" | rmcr | sed s%/c/%%)"
@@ -645,6 +642,9 @@ declare_variables() {
 parse_options() {
   local Shortoptions Longoptions Parsererror
 
+  [ "$0" = "$BASH_SOURCE" ] && Sourced="no" || Sourced="yes"
+  verbose "Script is being sourced yes/no: $Sourced"
+
   Shortoptions="dghv"
   Longoptions="cleanup,clipboard::,desktop,display:,gpu,help,no-auth,size:,vcxsrv,verbose,version,xwin"
   Longoptions="$Longoptions,ip:" # experimental
@@ -660,7 +660,7 @@ parse_options() {
       -d|--desktop)       Desktopmode="yes" ;;
          --display)       Newdisplaynumber="${2:-}" ; shift ;;
       -g|--gpu)           Sharegpu="yes" ;;
-      -h|--help)          usage; finish ;;
+      -h|--help)          usage; Exitcode=0 ;;
          --ip)            Hostip="${2:-}" ; shift ;;
          --no-auth)       Xauthentication="no" ;;
          --size)          Screensize="${2:-}" ; shift ;;
@@ -779,7 +779,7 @@ export XAUTHORITY=$XAUTHORITY" > "$Xenvfile"
 trap finish EXIT
 declare_variables
 parse_options "$@"
-check_host
-[ "$Cleanup" = "yes" ] && cleanup && Exitcode="${Exitcode:-0}"
-[ -z "$Exitcode" ]     && main
+[ -z "$Exitcode" ] && check_host
+[ -z "$Exitcode" ] && [ "$Cleanup" = "yes" ] && cleanup && Exitcode="${Exitcode:-0}"
+[ -z "$Exitcode" ] && main
 finish "${Exitcode:-0}"


### PR DESCRIPTION
Added line to check for the internal host IP before checking the external IP addresses.

Also now parse the options before calling check_host, so that any passed in options can be used in the check_host function.